### PR TITLE
CMakeLists.txt: don't use CMAKE_INSTALL_FULL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,5 @@ configure_file(template-library.pc.in template-library.pc @ONLY)
 # Install directives
 install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TARGET})
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/template-library.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/template-library.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 


### PR DESCRIPTION
Because of a CMake issue [1], CMAKE_INSTALL_FULL_LIBDIR does not point
to a location under CMAKE_STAGING_PREFIX, but defaults to
"/usr/local/lib".
CMAKE_INSTALL_LIBDIR on the other hand is properly taking the value of
CMAKE_STAGING_PREFIX into account, and can be safely used as in practice
it's always an absolute path.

[1]: https://gitlab.kitware.com/cmake/cmake/issues/17340